### PR TITLE
Fixed Bug: Duplicate Line Item Keys in API response

### DIFF
--- a/bangazon/urls.py
+++ b/bangazon/urls.py
@@ -8,23 +8,23 @@ from bangazonapi.views import *
 
 # pylint: disable=invalid-name
 router = routers.DefaultRouter(trailing_slash=False)
-router.register(r'products', Products, 'product')
-router.register(r'productcategories', ProductCategories, 'productcategory')
-router.register(r'lineitems', LineItems, 'orderproduct')
-router.register(r'customers', Customers, 'customer')
-router.register(r'users', Users, 'user')
-router.register(r'orders', Orders, 'order')
-router.register(r'cart', Cart, 'cart')
-router.register(r'paymenttypes', Payments, 'payment')
-router.register(r'profile', Profile, 'profile')
+router.register(r"products", Products, "product")
+router.register(r"productcategories", ProductCategories, "productcategory")
+router.register(r"lineitems", LineItems, "orderproduct")
+router.register(r"customers", Customers, "customer")
+router.register(r"users", Users, "user")
+router.register(r"orders", Orders, "order")
+router.register(r"cart", Cart, "cart")
+router.register(r"payment-types", Payments, "payment")
+router.register(r"my-profile", Profile, "profile")
 
 
 # Wire up our API using automatic URL routing.
 # Additionally, we include login URLs for the browsable API.
 urlpatterns = [
-    path('', include(router.urls)),
-    path('register', register_user),
-    path('login', login_user),
-    path('api-token-auth', obtain_auth_token),
-    path('api-auth', include('rest_framework.urls', namespace='rest_framework')),
+    path("", include(router.urls)),
+    path("register", register_user),
+    path("login", login_user),
+    path("api-token-auth", obtain_auth_token),
+    path("api-auth", include("rest_framework.urls", namespace="rest_framework")),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -9,22 +9,36 @@ from .productrating import ProductRating
 
 
 class Product(SafeDeleteModel):
-
     _safedelete_policy = SOFT_DELETE
-    name = models.CharField(max_length=50,)
+    name = models.CharField(
+        max_length=50,
+    )
     customer = models.ForeignKey(
-        Customer, on_delete=models.DO_NOTHING, related_name='products')
+        Customer, on_delete=models.DO_NOTHING, related_name="products"
+    )
     price = models.FloatField(
-        validators=[MinValueValidator(0.00), MaxValueValidator(10000.00)],)
-    description = models.CharField(max_length=255,)
-    quantity = models.IntegerField(validators=[MinValueValidator(0)],)
+        validators=[MinValueValidator(0.00), MaxValueValidator(10000.00)],
+    )
+    description = models.CharField(
+        max_length=255,
+    )
+    quantity = models.IntegerField(
+        validators=[MinValueValidator(0)],
+    )
     created_date = models.DateField(auto_now_add=True)
     category = models.ForeignKey(
-        ProductCategory, on_delete=models.DO_NOTHING, related_name='products')
-    location = models.CharField(max_length=50,)
+        ProductCategory, on_delete=models.DO_NOTHING, related_name="products"
+    )
+    location = models.CharField(
+        max_length=50,
+    )
     image_path = models.ImageField(
-        upload_to='products', height_field=None,
-        width_field=None, max_length=None, null=True)
+        upload_to="products",
+        height_field=None,
+        width_field=None,
+        max_length=None,
+        null=True,
+    )
 
     @property
     def number_sold(self):
@@ -34,7 +48,8 @@ class Product(SafeDeleteModel):
             int -- Number items on completed orders
         """
         sold = OrderProduct.objects.filter(
-            product=self, order__payment_type__isnull=False)
+            product=self, order__payment_type__isnull=False
+        )
         return sold.count()
 
     @property
@@ -58,6 +73,8 @@ class Product(SafeDeleteModel):
             number -- The average rating for the product
         """
         ratings = ProductRating.objects.filter(product=self)
+        if ratings.size == 0:
+            return 0
         total_rating = 0
         for rating in ratings:
             total_rating += rating.rating
@@ -66,5 +83,5 @@ class Product(SafeDeleteModel):
         return avg
 
     class Meta:
-        verbose_name = ("product")
-        verbose_name_plural = ("products")
+        verbose_name = "product"
+        verbose_name_plural = "products"

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -1,4 +1,5 @@
 """View module for handling requests about customer profiles"""
+
 import datetime
 from django.http import HttpResponseServerError
 from django.contrib.auth.models import User
@@ -16,6 +17,7 @@ from .order import OrderSerializer
 
 class Profile(ViewSet):
     """Request handlers for user profile info in the Bangazon Platform"""
+
     permission_classes = (IsAuthenticatedOrReadOnly,)
 
     def list(self, request):
@@ -81,17 +83,20 @@ class Profile(ViewSet):
             }
         """
         try:
-            current_user = Customer.objects.get(user=4)
-            current_user.recommends = Recommendation.objects.filter(recommender=current_user)
+            current_user = Customer.objects.get(user=request.user.id)
+            current_user.recommends = Recommendation.objects.filter(
+                recommender=current_user
+            )
 
             serializer = ProfileSerializer(
-                current_user, many=False, context={'request': request})
+                current_user, many=False, context={"request": request}
+            )
 
             return Response(serializer.data)
         except Exception as ex:
             return HttpResponseServerError(ex)
 
-    @action(methods=['get', 'post', 'delete'], detail=False)
+    @action(methods=["get", "post", "delete"], detail=False)
     def cart(self, request):
         """Shopping cart manipulation"""
 
@@ -112,13 +117,14 @@ class Profile(ViewSet):
             @apiError (404) {String} message  Not found message.
             """
             try:
-                open_order = Order.objects.get(
-                    customer=current_user, payment_type=None)
+                open_order = Order.objects.get(customer=current_user, payment_type=None)
                 line_items = OrderProduct.objects.filter(order=open_order)
                 line_items.delete()
                 open_order.delete()
             except Order.DoesNotExist as ex:
-                return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+                return Response(
+                    {"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND
+                )
 
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 
@@ -175,20 +181,23 @@ class Profile(ViewSet):
             @apiError (404) {String} message  Not found message
             """
             try:
-                open_order = Order.objects.get(
-                    customer=current_user, payment_type=None)
+                open_order = Order.objects.get(customer=current_user, payment_type=None)
                 line_items = OrderProduct.objects.filter(order=open_order)
                 line_items = LineItemSerializer(
-                    line_items, many=True, context={'request': request})
+                    line_items, many=True, context={"request": request}
+                )
 
                 cart = {}
-                cart["order"] = OrderSerializer(open_order, many=False, context={
-                                                'request': request}).data
+                cart["order"] = OrderSerializer(
+                    open_order, many=False, context={"request": request}
+                ).data
                 cart["order"]["line_items"] = line_items.data
                 cart["order"]["size"] = len(line_items.data)
 
             except Order.DoesNotExist as ex:
-                return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+                return Response(
+                    {"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND
+                )
 
             return Response(cart["order"])
 
@@ -243,19 +252,19 @@ class Profile(ViewSet):
                 open_order.save()
 
             line_item = OrderProduct()
-            line_item.product = Product.objects.get(
-                pk=request.data["product_id"])
+            line_item.product = Product.objects.get(pk=request.data["product_id"])
             line_item.order = open_order
             line_item.save()
 
             line_item_json = LineItemSerializer(
-                line_item, many=False, context={'request': request})
+                line_item, many=False, context={"request": request}
+            )
 
             return Response(line_item_json.data)
 
         return Response({}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
-    @action(methods=['get'], detail=False)
+    @action(methods=["get"], detail=False)
     def favoritesellers(self, request):
         """
         @api {GET} /profile/favoritesellers GET favorite sellers
@@ -307,7 +316,8 @@ class Profile(ViewSet):
         favorites = Favorite.objects.filter(customer=customer)
 
         serializer = FavoriteSerializer(
-            favorites, many=True, context={'request': request})
+            favorites, many=True, context={"request": request}
+        )
         return Response(serializer.data)
 
 
@@ -317,11 +327,12 @@ class LineItemSerializer(serializers.HyperlinkedModelSerializer):
     Arguments:
         serializers
     """
+
     product = ProductSerializer(many=False)
 
     class Meta:
         model = OrderProduct
-        fields = ('id', 'product')
+        fields = ("id", "product")
         depth = 1
 
 
@@ -331,36 +342,49 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
     Arguments:
         serializers
     """
+
     class Meta:
         model = User
-        fields = ('first_name', 'last_name', 'email')
+        fields = ("first_name", "last_name", "email")
         depth = 1
 
 
 class CustomerSerializer(serializers.ModelSerializer):
     """JSON serializer for recommendation customers"""
+
     user = UserSerializer()
 
     class Meta:
         model = Customer
-        fields = ('id', 'user',)
+        fields = (
+            "id",
+            "user",
+        )
 
 
 class ProfileProductSerializer(serializers.ModelSerializer):
     """JSON serializer for products"""
+
     class Meta:
         model = Product
-        fields = ('id', 'name',)
+        fields = (
+            "id",
+            "name",
+        )
 
 
 class RecommenderSerializer(serializers.ModelSerializer):
     """JSON serializer for recommendations"""
+
     customer = CustomerSerializer()
     product = ProfileProductSerializer()
 
     class Meta:
         model = Recommendation
-        fields = ('product', 'customer',)
+        fields = (
+            "product",
+            "customer",
+        )
 
 
 class ProfileSerializer(serializers.ModelSerializer):
@@ -369,13 +393,21 @@ class ProfileSerializer(serializers.ModelSerializer):
     Arguments:
         serializers
     """
+
     user = UserSerializer(many=False)
     recommends = RecommenderSerializer(many=True)
 
     class Meta:
         model = Customer
-        fields = ('id', 'url', 'user', 'phone_number',
-                  'address', 'payment_types', 'recommends',)
+        fields = (
+            "id",
+            "url",
+            "user",
+            "phone_number",
+            "address",
+            "payment_types",
+            "recommends",
+        )
         depth = 1
 
 
@@ -388,7 +420,7 @@ class FavoriteUserSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = User
-        fields = ('first_name', 'last_name', 'username')
+        fields = ("first_name", "last_name", "username")
         depth = 1
 
 
@@ -403,7 +435,11 @@ class FavoriteSellerSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = Customer
-        fields = ('id', 'url', 'user',)
+        fields = (
+            "id",
+            "url",
+            "user",
+        )
         depth = 1
 
 
@@ -418,5 +454,5 @@ class FavoriteSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = Favorite
-        fields = ('id', 'seller')
+        fields = ("id", "seller")
         depth = 2

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -181,25 +181,24 @@ class Profile(ViewSet):
             @apiError (404) {String} message  Not found message
             """
             try:
+                # Gets current_user's order, where no payment is yet given
                 open_order = Order.objects.get(customer=current_user, payment_type=None)
-                line_items = OrderProduct.objects.filter(order=open_order)
-                line_items = LineItemSerializer(
-                    line_items, many=True, context={"request": request}
-                )
+                # Gets all order/product relationships associated with customer's open order id
 
+                # Initializes empty dictionary to send in response to client
                 cart = {}
+                # Creates new dictionary key holding serialized data following OrderSerializer pattern
                 cart["order"] = OrderSerializer(
                     open_order, many=False, context={"request": request}
                 ).data
-                cart["order"]["line_items"] = line_items.data
-                cart["order"]["size"] = len(line_items.data)
-
+                # Calculates the size of an order by list containing line_items
+                cart["order"]["size"] = len(cart["order"]["lineitems"])
             except Order.DoesNotExist as ex:
                 return Response(
                     {"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND
                 )
 
-            return Response(cart["order"])
+            return Response(cart["order"], status=status.HTTP_200_OK)
 
         if request.method == "POST":
             """

--- a/bangazonapi/views/register.py
+++ b/bangazonapi/views/register.py
@@ -1,4 +1,5 @@
 """Register user"""
+
 import json
 from django.http import HttpResponse, HttpResponseNotAllowed
 from django.contrib.auth import authenticate
@@ -11,62 +12,65 @@ from bangazonapi.models import Customer
 
 @csrf_exempt
 def login_user(request):
-    '''Handles the authentication of a user
+    """Handles the authentication of a user
 
     Method arguments:
       request -- The full HTTP request object
-    '''
+    """
 
-    body = request.body.decode('utf-8')
+    body = request.body.decode("utf-8")
     req_body = json.loads(body)
 
     # If the request is a HTTP POST, try to pull out the relevant information.
-    if request.method == 'POST':
-
+    if request.method == "POST":
         # Use the built-in authenticate method to verify
-        name = req_body['username']
-        pass_word = req_body['password']
-        authenticated_user = authenticate(username=name, password=pass_word)
+        name = req_body["username"]
+        password = req_body["password"]
+        authenticated_user = authenticate(username=name, password=password)
 
         # If authentication was successful, respond with their token
         if authenticated_user is not None:
             token = Token.objects.get(user=authenticated_user)
-            data = json.dumps({"valid": True, "token": token.key, "id": authenticated_user.id})
-            return HttpResponse(data, content_type='application/json')
+            data = json.dumps(
+                {"valid": True, "token": token.key, "id": authenticated_user.id}
+            )
+            return HttpResponse(data, content_type="application/json")
 
         else:
             # Bad login details were provided. So we can't log the user in.
+            #
             data = json.dumps({"valid": False})
-            return HttpResponse(data, content_type='application/json')
+            return HttpResponse(data, content_type="application/json")
 
-    return HttpResponseNotAllowed(permitted_methods=['POST'])
+    return HttpResponseNotAllowed(permitted_methods=["POST"])
 
 
 @csrf_exempt
 def register_user(request):
-    '''Handles the creation of a new user for authentication
+    """Handles the creation of a new user for authentication
 
     Method arguments:
       request -- The full HTTP request object
-    '''
+    """
 
     # Load the JSON string of the request body into a dict
-    req_body = json.loads(request.body.decode())
+    req_body = json.loads(request.body.decode("utf-8"))
 
     # Create a new user by invoking the `create_user` helper method
     # on Django's built-in User model
     new_user = User.objects.create_user(
-        username=req_body['username'],
-        email=req_body['email'],
-        password=req_body['password'],
-        first_name=req_body['first_name'],
-        last_name=req_body['last_name']
+        username=req_body["username"],
+        email=req_body["email"],
+        password=req_body["password"],
+        first_name=req_body["first_name"],
+        last_name=req_body["last_name"],
     )
+    new_user.save()
 
     customer = Customer.objects.create(
-        phone_number=req_body['phone_number'],
-        address=req_body['address'],
-        user=new_user
+        phone_number=req_body["phone_number"],
+        address=req_body["address"],
+        user=new_user,
     )
 
     # Commit the user to the database by saving it
@@ -74,7 +78,10 @@ def register_user(request):
 
     # Use the REST Framework's token generator on the new user account
     token = Token.objects.create(user=new_user)
+    token.save()
 
     # Return the token to the client
     data = json.dumps({"token": token.key, "id": new_user.id})
-    return HttpResponse(data, content_type='application/json', status=status.HTTP_201_CREATED)
+    return HttpResponse(
+        data, content_type="application/json", status=status.HTTP_201_CREATED
+    )


### PR DESCRIPTION
When a user's client makes an API request at address: `http://localhost:8000/my-profile/cart`. They would receive the correct data; that is, the order that they have opened and for which they have not submitted payment. The API response would include expanded data of their open order, the products associated with that order, and data relevant to each individual product. 

## Changes
In module: `bangazonapi/views/profile.py` lines 183 - 201
- Added comments to more readily understand what the code is doing.
- Removed **line_items** variable. It was being reassigned to hold OrderProducts filtered by the current user's open order that was received from the database to later hold serialized data. However, OrderProducts has two foreign key fields in the model with the same related name *lineitem*. The `OrderSerializer` on line 191 of the same module is aware of these foreign key fields and includes a specific field for these related names. 
- The **line_items** variable was then being passed to the `LineItemSerializer` defined in the same module lines 323 - 335. Thought, the docstring hints that this `LineItemSerializer` is used when creating new product-to-order relationships, not necessarily for rendering serialized data representing products on an order. The `OrderSerializer` is still responsible for this purpose. 

## Requests / Responses

Our team altered the route at which the profile view is managed in `bangazon/urls.py`. On line 19, we changed the route from "profile" to "my-profile". This change should be reflected in any requests made to the API. 

**Request**

GET `http://localhost:8000/my-profile/cart` Returns a list of products associated with an authenticated user's order, if the order is still open. 

No body is required for this request, but that the headers contain an Authorization key and the keyword **Token** accompanied by an authorized user's token value.  

Here is an example header: 

headers {
      Authorization: Token 9ba45f09651c5b0c404f37a2d2572c026c14669c,
}

**Response**

HTTP/1.1 200 OK

```json
{
  "id": 2,
  "url": "http://localhost:8000/orders/2",
  "created_date": "2019-04-12",
  "payment_type": null,
  "customer": "http://localhost:8000/customers/7",
  "lineitems": [
    {
      "id": 4,
      "product": {
        "id": 52,
        "name": "Golf",
        "price": 653.59,
        "number_sold": 0,
        "description": "1994 Volkswagen",
        "quantity": 4,
        "created_date": "2019-07-10",
        "location": "Berlin",
        "image_path": "http://localhost:8000/media/products/vehicle.png"
      }
    },
    {
      "id": 5,
      "product": {
        "id": 33,
        "name": "Optima",
        "price": 1655.15,
        "number_sold": 0,
        "description": "2008 Kia",
        "quantity": 3,
        "created_date": "2019-05-21",
        "location": "New York",
        "image_path": "http://localhost:8000/media/products/vehicle.png"
      }
    },
    {
      "id": 6,
      "product": {
        "id": 71,
        "name": "Optima",
        "price": 1655.15,
        "number_sold": 0,
        "description": "2008 Kia",
        "quantity": 3,
        "created_date": "2019-05-21",
        "location": "London",
        "image_path": "http://localhost:8000/media/products/vehicle.png"
      }
    }
  ],
  "size": 3
}
```

## Testing

The issue was that the API response was sending back duplicate data. The way to test this code is by sending a GET request from an authorized user to this API URL. You may do this either in Yaak or Postman. There is not yet any client-side testing implemented for this bugfix yet. 

## Related Issues

- Fixes #1 Bug: Cart resource has duplicate items.