### PR TITLE
Bug Fix: Unable to Complete an Order (#31)

### DIFF
--- a/bangazonapi/views/cart.py
+++ b/bangazonapi/views/cart.py
@@ -3,13 +3,48 @@ import datetime
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 from rest_framework import status
-from bangazonapi.models import Order, Customer, Product, OrderProduct
+from rest_framework.decorators import action
+from bangazonapi.models import Order, Customer, Product, OrderProduct, Payment
 from .product import ProductSerializer
 from .order import OrderSerializer
 
 
+
 class Cart(ViewSet):
     """Shopping cart for Bangazon eCommerce"""
+    @action(methods=['post'], detail=False)
+    def  complete(self,request):
+
+        current_user = Customer.objects.get(user = request.auth.user)
+
+        try:
+
+            payment_type_id = request.data.get("payment_type_id")
+            print("Payment Type ID from request:", payment_type_id )
+
+            
+            open_order = Order.objects.filter(
+                    customer = current_user,
+                    payment_type__isnull = True
+                ).first()
+            if not open_order:
+                return Response({'message': 'No open order found'}, status=status.HTTP_400_BAD_REQUEST)
+            payment_type = Payment.objects.get(pk=payment_type_id)
+            open_order.payment_type = payment_type
+            open_order.save()
+
+            new_order = Order.objects.create(
+            customer=current_user,
+            created_date=datetime.datetime.now(),
+            payment_type=None
+            )
+            return Response({
+                'message': 'Order completed',
+                'completed_order_id': open_order.id,
+                'new_order_id': new_order.id
+            }, status=status.HTTP_200_OK)
+        except Exception as ex:
+            return Response(ex, status=status.HTTP_400_BAD_REQUEST)
 
     def create(self, request):
         """


### PR DESCRIPTION
**Summary**
This PR fixes the bug where completing an order did not work from the cart. It allows customers to properly complete their open cart by selecting a payment type, updates the order accordingly, and automatically creates a new open cart.

**Changes Made**

- Updated CartViewSet with a complete action
- Linked selected payment_type via payment_type_id from the frontend
- Ensured only one open order at a time using .filter().first()
- Added error handling for missing open orders and invalid payment types
- Frontend Integration
- Integrated with CompleteFormModal
- Ensures payment_type_id is passed correctly from the dropdown
- Added parseInt for safety when selecting payment type

**Frontend Integration**

- Integrated with CompleteFormModal
- Ensures payment_type_id is passed correctly from the dropdown
- Added parseInt for safety when selecting payment type

**Bug Fixes**

- Fixed issue where multiple open orders caused MultipleObjectsReturned errors
- Prevented null payment types from being saved to completed orders

**Test**

1. Go to the cart
2. Open the “Complete Order” modal
3. Select a payment type
4. Click “Complete Order”
