### PR TITLE
Fixed Key Name errors in Payment's POST and Payment's GET

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -45,8 +45,8 @@ class Payments(ViewSet):
             Response -- JSON serialized payment instance
         """
         new_payment = Payment()
-        new_payment.merchant_name = request.data["merchant"]
-        new_payment.account_number = request.data["acctNumber"]
+        new_payment.merchant_name = request.data["merchant_name"]
+        new_payment.account_number = request.data["account_number"]
         new_payment.expiration_date = request.data["expiration_date"]
         customer = Customer.objects.get(user=request.auth.user)
         new_payment.customer = customer
@@ -94,10 +94,10 @@ class Payments(ViewSet):
         try:
             payment_types = Payment.objects.all()
             current_user = Customer.objects.get(user=request.auth.user)
-            customer_id = current_user
+            customer = current_user
 
-            if customer_id is not None:
-                payment_types = payment_types.filter(customer__id=customer_id.user_id)
+            if customer is not None:
+                payment_types = payment_types.filter(customer__id=customer.id)
 
                 serializer = PaymentSerializer(
                     payment_types, many=True, context={"request": request}


### PR DESCRIPTION
This pull request fixes key name errors in the API. The API was expecting the key names "merchant" and "acctNumber", but the client was sending the key names "merchant_name" and "account_number". The API key names are now expecting the latter names on the request body. 
## Changes

- Changed key names API was expecting to the request body's key names.
- Renamed a variable in the fetching of a customer's payment methods. The wrong id was being accessed. Originally, we were using `user_id`, but we get the customer that is sending the request. Their customer `id` is associated with the payment method that they are creating. This ensure that they receive only their payment methods.

## Requests / Responses

**Request**

POST `/payment-types` Creates a new payment method

```json
{
    "merchant_name": "Visa",
    "account_number": "1111-1111-1111",
    "expiration_date": "2025-12-31",
}
```

**Response**

HTTP/1.1 201 OK

```json
{
  "id": 8,
  "url": "http://localhost:8000/payment-types/8",
  "merchant_name": "Visa",
  "account_number": "1111-1111-1111",
  "obscured_account_number": "**********1111",
  "expiration_date": "2025-12-31",
  "create_date": "2025-04-04"
}
```

## Testing

To test this code, you may either pull this request to your computer and try it out on the front-end or send a request via Postman or Yaak following the pattern set above. 

## Related Issues

- Fixes Issue #7 (found in client-side repo) is the original issue. We had completed this issue ticket some time ago, but this bug was recently introduced during out developing of the web application. This pull request should return the status of the issue ticket to completed. 