### PR TITLE
Updated key names in `tests/payments.py`

### DIFF
--- a/tests/payments.py
+++ b/tests/payments.py
@@ -31,8 +31,8 @@ class PaymentTests(APITestCase):
         # Add product to order
         url = "/payment-types"
         data = {
-            "merchant": "American Express",
-            "acctNumber": "111-1111-1111",
+            "merchant_name": "American Express",
+            "account_number": "111-1111-1111",
             "expiration_date": "2024-12-31",
         }
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)


### PR DESCRIPTION
After updating the key names for creating a new payment both on the client-side of the web application and at route `bangazonapi/views/paymenttype.py`. We overlooked making the change and enforcing consistency in the test module for the payment method POST request.

## Changes

- Renamed key names on data dictionary in `tests/payments.py` to reflect the key names required in the payment class POST request. Here is the current format the API is expecting when making this POST request:

![image](https://github.com/user-attachments/assets/12472597-228f-43c6-9062-363340f8e3f4)


## Testing
This pull request covers changes made in the tests' directory. Running tests is the main form of ensuring that the code and logic in the `tests/payments.py` is executing properly. 

- [ ] Run test suite


## Related Issues
This is a bug that was introduced during the development process. There is no created issue ticket for this bug. 