### PR TITLE
Configured Profile Serializer to include new store field

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -444,7 +444,15 @@ class ProfileSerializer(serializers.ModelSerializer):
 
     user = UserSerializer(many=False)
     recommends = RecommenderSerializer(many=True)
+    store = serializers.SerializerMethodField()
 
+    def get_store(self, pbj):
+        store = {}
+        store["name"] = pbj.store_name
+        store["description"] = pbj.store_description
+        store["id"] = pbj.id
+
+        return store
     class Meta:
         model = Customer
         fields = (
@@ -455,6 +463,7 @@ class ProfileSerializer(serializers.ModelSerializer):
             "address",
             "payment_types",
             "recommends",
+            "store",
         )
         depth = 1
 


### PR DESCRIPTION
We recently implemented a feature that allows a customer to create a store. The user would have a view of their store and the products that they are selling. However, after a customer had created a store, when the response is received, the web application cannot properly process the response which it uses to navigate users to their newly created store.

# Bug Location and Logic
The bug was first traced from this module on the client: `pages/stores/new.js` 

Here is a screenshot of the NextJS error window:
![image](https://github.com/user-attachments/assets/fef21df6-4254-4661-917f-2472d8f4ebac)
 
The function defined in this window is expecting the response a customer receives after creating a store to include a unique id to navigate the user to their store. The response did not include this id.
# Changes

- In order to fulfill the requirements of navigating a user to their unique store, we modified the profile serializer to contain a collection of data about a customer's store, now included directly on the customer model. 

- The serializer now includes a custom serializer method field that generates this collection of data from customer data to form it into a proper response. The `store` field now included in the profile serializer is built out with three keys. Here is the pattern for the expected store dictionary:

```py
store{
              "id": {customer.id}, 
              "name": {customer.store_name},
              "description": {customer.store_description}
```
- Now, with the proper response being sent to the client, they can navigate properly to a customer's store directly after creating it.

## Testing

It is best to go ahead and remigrate and reseed your database before testing this bugfix. The customer model has been modified to include two new fields. We believe that storing this data directly on a customer will be most beneficial. After all, our customers will have unique ids of their own and can only own one store. Their store will share their personal unique id. 

- [ ] Run migrations
- [ ] Seed database


## Related Issues

- Fixes a bug in the feature implementation of issue ticket #20 in the client-side repository. 