### PR TITLE
Refactored GETting likes to be on the profile instead of products

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -403,14 +403,17 @@ class Products(ViewSet):
     @action(methods=["post", "delete"], detail=True)
     def like(self, request, pk=True):
 
-        customer = Customer.objects.get(user=request.auth.user)
-        product = Product.objects.get(pk=pk)
-
         try:
-            if Like.objects.filter(customer=customer, product=product).exists():
-                Like.objects.get(customer=customer, product=product).delete()
+            customer = Customer.objects.get(user=request.auth.user)
+            product = Product.objects.get(pk=pk)
+        except Product.DoesNotExist as Ex:
+            return Response(f"Details: {ex.args[0]}", status=status.HTTP_404_NOT_FOUND)
+        try:
+            customer_liked_products =  Like.objects.filter(customer=customer, product=product)
+            if customer_liked_products.exists():
+                customer_liked_products.delete()
                 return Response("deleted", status=status.HTTP_204_NO_CONTENT)
-
+            
             like = Like()
             like.customer = Customer.objects.filter(user=request.auth.user).first()
             like.product = Product.objects.filter(pk=pk).first()
@@ -420,19 +423,19 @@ class Products(ViewSet):
         except Exception as ex:
             return Response({"error": ex}, status=status.HTTP_404_NOT_FOUND)
 
-    @action(methods=["get"], detail=False)
-    def liked(self, request):
+    # @action(methods=["get"], detail=False)
+    # def liked(self, request):
 
-        products = Product.objects.all()
+    #     products = Product.objects.all()
 
-        serializer = ProductSerializer(
-            products, many=True, context={"request": request}
-        )
+    #     serializer = ProductSerializer(
+    #         products, many=True, context={"request": request}
+    #     )
 
-        response_data = serializer.data
-        filtered_data = [product for product in response_data if product["is_liked"]]
+    #     response_data = serializer.data
+    #     filtered_data = [product for product in response_data if product["is_liked"]]
 
-        return Response(filtered_data, status=status.HTTP_200_OK)
+    #     return Response(filtered_data, status=status.HTTP_200_OK)
 
     @action(methods=["post", "delete"], detail=True)
     def rate(self, request, pk=None):

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -423,20 +423,6 @@ class Products(ViewSet):
         except Exception as ex:
             return Response({"error": ex}, status=status.HTTP_404_NOT_FOUND)
 
-    # @action(methods=["get"], detail=False)
-    # def liked(self, request):
-
-    #     products = Product.objects.all()
-
-    #     serializer = ProductSerializer(
-    #         products, many=True, context={"request": request}
-    #     )
-
-    #     response_data = serializer.data
-    #     filtered_data = [product for product in response_data if product["is_liked"]]
-
-    #     return Response(filtered_data, status=status.HTTP_200_OK)
-
     @action(methods=["post", "delete"], detail=True)
     def rate(self, request, pk=None):
         """Rate a product"""

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -11,7 +11,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 from bangazonapi.models import Order, Customer, Product
 from bangazonapi.models import OrderProduct, Favorite
-from bangazonapi.models import Recommendation
+from bangazonapi.models import Recommendation, Like
 from .product import ProductSerializer
 from .order import OrderSerializer
 
@@ -505,6 +505,7 @@ class ProfileSerializer(serializers.ModelSerializer):
     recommended = RecommenderSerializer(many=True)
     store = serializers.SerializerMethodField()
     favorites = serializers.SerializerMethodField()
+    liked_products = serializers.SerializerMethodField()
 
     def get_favorites(self, obj):
         # Finds the customer who is making the request for their profile
@@ -531,7 +532,23 @@ class ProfileSerializer(serializers.ModelSerializer):
         store["id"] = pbj.id
 
         return store
+    
+    def get_liked_products(self, obj):
+        # Finds the customer who is making the request for their profile
+        customer = Customer.objects.get(user=self.context["request"].user)
 
+        # Filters all product-like relationships based on what this customer has liked
+        likes = Like.objects.filter(customer=customer)
+
+        # Gets product objects from the product-likes relationship
+        liked_products = [like.product for like in likes]
+
+        # Serialize this customer's liked products
+        serializer = ProductSerializer(liked_products, many=True, context={"request": self.context["request"]})
+
+        # return a serialized list of liked products to be included in the likes field
+        return serializer.data
+    
     class Meta:
         model = Customer
         fields = (
@@ -545,6 +562,7 @@ class ProfileSerializer(serializers.ModelSerializer):
             "recommended",
             "store",
             "favorites",
+            "liked_products",
         )
         depth = 1
 


### PR DESCRIPTION
The changes made in this pull request moves the logic that was found in the `@action` at route `"/profile/liked"`. We were making a separate fetch call to this route. Instead of leaving this logic at this route, we integrated it into the profile. The route  `"/profile/liked"` still exists, its responsibilities have changed. The logic for handling GET has now been added to the `ProfileSerializer`

## Changes

- Ran into a bug while testing liking and unliking products. If a user spammed this button, it would cause bad data in the database. We added a `try...except` block that would handle this spamming.

- We needed the `Like` model in the profile viewset, so we included it in an import from the `bangazonapi.models` statements

- Created a new serializer field on the profile: `liked_products`

- Created a new custom serializer method: `get_liked_products`. This custom serializer field will filter all of the likes-to-product relationship on the basis of the customer that created those relationships. Once these relationships are received, we iterate through them to get the products that are associated with these relationships. 

## Requests / Responses

To ensure that this GET logic is performing properly, you must first create a product-to-like relationship. 

**Request**

POST `/products/:product_id/liked` Creates a new product-to-like relationship with the product and the authenticated user/customer

This request does not need a body, but relies upon a product's unique id. This unique id needs to be included in the API URL. Remember to use the `Authorization` header with a valid token when making a request to one of the URLs

**Response**

HTTP/1.1 201 Created

**Request**

GET `/profile` Gets an authenticated user's customer profile

You do not need to send a body when making this request. Ensure that you are using the `Authorization` header with a valid user-token.

**Response**

HTTP/1.1 200 OK

You should see that output of the user's customer profile with a new key, `liked_products`. If you have sent a request to like a product, including the product `id` in the API URL, you will see the product object in a list on this key. Otherwise, if you have not liked a product, the value will be an initialized, empty list. 

## Testing

Make sure to reseed the database. There has been no changes to any models during this refactor. There has also been no changes or additions to the tests' directory. There should be no reason to run the test suite. 

- [ ] Seed database
- [ ] Created a product-to-like relationship
- [ ] Used the HTTP command GET with URL endpoint `"/profile"`


## Related Issues

- Issue #63, found in the client-side repository 