### PR TITLE
Serialized likes count on products

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -21,6 +21,7 @@ class ProductSerializer(serializers.ModelSerializer):
 
     is_liked = serializers.SerializerMethodField()
     avg_rating = serializers.SerializerMethodField()
+    likes = serializers.SerializerMethodField()
 
     class Meta:
         model = Product
@@ -38,6 +39,7 @@ class ProductSerializer(serializers.ModelSerializer):
             "can_be_rated",
             "ratings",
             "is_liked",
+            "likes"
         )
         depth = 4
 
@@ -47,6 +49,13 @@ class ProductSerializer(serializers.ModelSerializer):
             return obj.is_liked(request, obj.id)
         return False
 
+    def get_likes(self, obj):
+        # Filters product-likes relationships based on product primary key
+        likes = Like.objects.filter(product=obj.id)
+
+        # Gets the length of the list containing all likes associated with this product
+        return len(likes)
+    
     def get_avg_rating(self, obj):
         return obj.avg_rating
 


### PR DESCRIPTION
Adds a new field on the specific products as they are being retrieved. This new field, `"likes"` is an aggregate of interactions between multiple users and one product. All of users can like a product once, we find how many of these relationships there are in the database and calculate its length, since the filter method returns a list. 

## Changes

- Added a new serializer field in the response to the client, `"Likes"`
- Created a new custom serializer method field that filters product-to-likes relationships on the basis of the product. The custom serializer method field then calculates the length of the returned filtered list, and that is the number of likes a product has.

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET `/products/1` Gets a product with new `"Likes"` field. If there are no likes on this particular product, you will receive an empty array

**Response**

HTTP/1.1 200 OK

## Testing

There is no real way to test this in the server, but it is fully functional with the client side and the changes I have made in the client-side pull request. To see this in process in action

- [ ] Login to the web application
- [ ] Select a product to view its details
- [ ] Click the `like` button. You will see the like counter increase by one.
- [ ] Add the product to your cart
- [ ] Complete the order by paying
- [ ] Navigate back to the purchased product
- [ ] You will see that the number of purchases will have increased by one as well. 


## Related Issues

- Fixes #71, found in the client-side repository. 