### PR TITLE
Changed dictionary key name to access the request body's category id

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -159,7 +159,7 @@ class Products(ViewSet):
         customer = Customer.objects.get(user=request.auth.user)
         new_product.customer = customer
 
-        product_category = ProductCategory.objects.get(pk=request.data["category_id"])
+        product_category = ProductCategory.objects.get(pk=request.data["categoryId"])
         new_product.category = product_category
 
         if "image_path" in request.data:

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -476,6 +476,7 @@ class ProfileProductSerializer(serializers.ModelSerializer):
             "id",
             "name",
             "image_path",
+            "price",
         )
 
 


### PR DESCRIPTION
There was an issue whenever a store owner wanted to add a product to there store. The issues stemmed from an improperly accessing a key on the request body sent by the store owner to add their new product. The key name `category_id` was changed to `categoryId`. This is the format that the API is expecting from the client. 

## Changes

- Changed key name during product creation to accept the key `categoryId` instead of `category_id`. This now allows our store owners to add products as they wish to their stores. 

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

## Testing

The functionality is available in the client for testing.

- [ ] Log into Bangazon
- [ ] Open a store if you have not yet, but navigated to the hamburger icon and select *Interested in selling?*
- [ ] Create your store
- [ ] Navigate again to the hamburger icon and select *Add a product*
- [ ] Fill out the product creation form
- [ ] Send the request to API by clicking the `Save` button
- [ ] You will be redirected to your new product's details page.


## Related Issues

There is no associated issue ticket for this bug. It was found during testing of the development branch