### PR TITLE
Readded register_user to python urls

### DIFF
--- a/bangazon/urls.py
+++ b/bangazon/urls.py
@@ -42,6 +42,7 @@ router.register(r"reports", ReportView, "order_report")
 urlpatterns = [
     path("", include(router.urls)),
     path("login", login_user, name="login"),
+    path("register", register_user, name="register"),
     path("admin/", admin.site.urls),
     path("api-token-auth", obtain_auth_token),
     path("api-auth", include("rest_framework.urls", namespace="rest_framework")),


### PR DESCRIPTION
Somewhere during merging our previous pull requests, the route to register was accidentally deleted in the `urls.py` module. This pull request readds the route so that we can register users again.

## Changes

- Readds an accidentally deleted route used to register new users to Bangazon.

## Testing

Their is front-end support for registered a user, and there is back end support for registering a user. It was fully functional, but was accidentally removed. You may test this through running the backend server and registering a user through the Bangazon app.

- [ ] Run the python server 
- [ ] Run the Bangazon app in development
- [ ] Instead of logging in either hit the `Sign up` button located in the top-right of the screen or below the login form
- [ ] Fill out the registration form to create a new registered, Bangazon user.
- [ ] Once you submit your form, your customer profile should be generated and you will be navigate to Bangazon's landing page.

## Related Issues

- There is no associated issue ticket for this bug, but was found during testing of the development branches on the server and client of this project. 